### PR TITLE
feat: Type generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { importApp } from "./import/importApp";
 import { importFromDialogflow } from "./import";
 import { profile } from "./profile";
 import { ExportOptions } from "./models/options";
-import { generateTypes } from "./types";
+import { generateTypes, GenerateTypesOptions } from "./types";
 
 program.version(pkg.version);
 
@@ -160,8 +160,10 @@ program
 program
     .command("types <directory> [appId]")
     .description("Generate the TypeScript types for the possible requests to the provided directory")
+    .option("-f --file <file>", "Optional file name, defaults to studio.ts")
     .option("-h --header <header>", "Optional header to add to the top of the file")
-    .action(async (directory: string, appId: string = undefined, options?: { header?: string }) => {
+    .option("-m --max <header>", "Optional limit for entity values to generate types, defaults to 20")
+    .action(async (directory: string, appId: string = undefined, options?: GenerateTypesOptions) => {
         await generateTypes(directory, appId, options);
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { importApp } from "./import/importApp";
 import { importFromDialogflow } from "./import";
 import { profile } from "./profile";
 import { ExportOptions } from "./models/options";
+import { generateTypes } from "./types";
 
 program.version(pkg.version);
 
@@ -156,6 +157,13 @@ program
         }
     });
 
+program
+    .command("types <directory> [appId]")
+    .description("Generate the TypeScript types for the possible requests to the provided directory")
+    .option("-h --header <header>", "Optional header to add to the top of the file")
+    .action(async (directory: string, appId: string = undefined, options?: { header?: string }) => {
+        await generateTypes(directory, appId, options);
+    });
 
 program
     .command("export <directory> [appId]")

--- a/src/types/generateTypes.ts
+++ b/src/types/generateTypes.ts
@@ -7,14 +7,17 @@ import { getStentorApp } from "../getStentorApp";
 
 import { existsAndNotEmpty } from "stentor-utils";
 import { intentToTypes } from "./utils/intentToTypes";
+import { entityToTypes } from "./utils/entityToTypes";
 
 export interface GenerateTypesOptions {
     header?: string;
+    file?: string;
+    max?: string;
 }
 
 export async function generateTypes(output: string, appId: string = undefined, options: GenerateTypesOptions): Promise<void> {
 
-    const { app, intents } = await getStentorApp(appId);
+    const { app, intents, entities } = await getStentorApp(appId);
 
     // Resolve the path
     const path = resolve(output);
@@ -31,21 +34,35 @@ export async function generateTypes(output: string, appId: string = undefined, o
         requests += `${options.header}\n`;
     }
     const HEADER = `/* This is a generated file */`;
-    const IMPORTS = `import { IntentRequest, RequestSlotMap } from "stentor";`;
+    const IMPORTS = `import { IntentRequest, Request, RequestSlotMap } from "stentor";`;
 
     requests += `${HEADER}\n${IMPORTS}\n\n`;
+
+    // Entities first
+    const availableEntities: { [type: string]: string } = {};
+    if (existsAndNotEmpty(entities)) {
+        entities.forEach((entity) => {
+            const max = Number.isNaN(Number(options.max)) ? undefined : Number(options.max);
+            const entityType = entityToTypes(entity, max);
+            if (entityType) {
+                requests += `${entityType}\n\n`;
+                // add is as available for use later
+                availableEntities[entity.entityId] = `${entity.entityId}_VALUES`;
+            }
+        })
+    }
 
     // Go through the intents and generate intents
     if (existsAndNotEmpty(intents)) {
         intents.forEach((intent) => {
             // convert the intent
-            requests += intentToTypes(intent);
+            requests += intentToTypes(intent, availableEntities);
             requests += `\n\n`;
         });
     }
 
     // print it to a file
-    const requestsPath = resolve(path, 'requests.ts');
+    const requestsPath = resolve(path, options?.file || 'studio.ts');
     writeFileSync(requestsPath, requests);
 
 }

--- a/src/types/generateTypes.ts
+++ b/src/types/generateTypes.ts
@@ -1,0 +1,51 @@
+/*! Copyright (c) 2022, XAPP AI*/
+
+import { log } from "stentor-logger";
+import { existsSync, writeFileSync } from "fs";
+import { resolve } from "path";
+import { getStentorApp } from "../getStentorApp";
+
+import { existsAndNotEmpty } from "stentor-utils";
+import { intentToTypes } from "./utils/intentToTypes";
+
+export interface GenerateTypesOptions {
+    header?: string;
+}
+
+export async function generateTypes(output: string, appId: string = undefined, options: GenerateTypesOptions): Promise<void> {
+
+    const { app, intents } = await getStentorApp(appId);
+
+    // Resolve the path
+    const path = resolve(output);
+
+    if (!existsSync(path)) {
+        throw new Error(`Path ${output} does not exist.  Please provide an existing path to create the export within.`);
+    }
+
+    log().info(`Exporting types for ${app.name} to ${path}`);
+
+    let requests = "";
+
+    if (options && options.header) {
+        requests += `${options.header}\n`;
+    }
+    const HEADER = `/* This is a generated file */`;
+    const IMPORTS = `import { IntentRequest, RequestSlotMap } from "stentor";`;
+
+    requests += `${HEADER}\n${IMPORTS}\n\n`;
+
+    // Go through the intents and generate intents
+    if (existsAndNotEmpty(intents)) {
+        intents.forEach((intent) => {
+            // convert the intent
+            requests += intentToTypes(intent);
+            requests += `\n\n`;
+        });
+    }
+
+    // print it to a file
+    const requestsPath = resolve(path, 'requests.ts');
+    writeFileSync(requestsPath, requests);
+
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./generateTypes";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
+/*! Copyright (c) 2022, XAPP AI*/
 export * from "./generateTypes";

--- a/src/types/utils/entityToTypes.ts
+++ b/src/types/utils/entityToTypes.ts
@@ -1,0 +1,23 @@
+/*! Copyright (c) 2022, XAPP AI*/
+import { Entity } from "stentor-models";
+
+export function entityToTypes(entity: Entity, max = 20): string {
+    let entityType = "";
+
+    // Only add if we have a manageable number of values
+    if (entity.type !== "REGEX" && entity.values.length <= max) {
+        const name = `${entity.entityId}_VALUES`;
+        entityType += `export type ${name} = `;
+        entity.values.forEach((value, index) => {
+            if (index === 0) {
+                entityType += `"${value.name}"`;
+            } else {
+                entityType += ` | "${value.name}"`
+            }
+        });
+
+        entityType += `;`;
+    }
+
+    return entityType;
+}

--- a/src/types/utils/intentToTypes.ts
+++ b/src/types/utils/intentToTypes.ts
@@ -5,7 +5,7 @@ import { slotsToTypes } from "./slotsToTypes";
 
 const FS = "    ";
 
-export function intentToTypes(intent: Intent): string {
+export function intentToTypes(intent: Intent, availableEntities: { [type: string]: string }): string {
 
     const name = `${intent.intentId}IntentRequest`;
 
@@ -15,7 +15,7 @@ export function intentToTypes(intent: Intent): string {
 
     if (existsAndNotEmpty(intent.slots)) {
         slotMapType = `${name}SlotMap`;
-        const slotTypes = slotsToTypes(intent.slots, slotMapType);
+        const slotTypes = slotsToTypes(intent.slots, slotMapType, availableEntities);
         intentType += slotTypes
         intentType += `\n\n`;
     }
@@ -28,6 +28,13 @@ export function intentToTypes(intent: Intent): string {
     }
 
     // close it off
+    intentType += `}`;
+
+    // Add the guard
+    intentType += `\n\n`;
+
+    intentType += `export function is${name}(request: Request): request is ${name} {\n`;
+    intentType += `${FS}return !!request && (request as IntentRequest).intentId === "${intent.intentId}";\n`;
     intentType += `}`;
 
     return intentType;

--- a/src/types/utils/intentToTypes.ts
+++ b/src/types/utils/intentToTypes.ts
@@ -1,0 +1,35 @@
+/*! Copyright (c) 2022, XAPP AI*/
+import { Intent } from "stentor-models";
+import { existsAndNotEmpty } from "stentor-utils";
+import { slotsToTypes } from "./slotsToTypes";
+
+const FS = "    ";
+
+export function intentToTypes(intent: Intent): string {
+
+    const name = `${intent.intentId}IntentRequest`;
+
+    let intentType = "";
+
+    let slotMapType: string;
+
+    if (existsAndNotEmpty(intent.slots)) {
+        slotMapType = `${name}SlotMap`;
+        const slotTypes = slotsToTypes(intent.slots, slotMapType);
+        intentType += slotTypes
+        intentType += `\n\n`;
+    }
+
+    intentType += `export interface ${name} extends IntentRequest {\n`;
+    intentType += `${FS}intentId: "${intent.intentId}";\n`
+
+    if (slotMapType) {
+        intentType += `${FS}slots: ${slotMapType};\n`;
+    }
+
+    // close it off
+    intentType += `}`;
+
+    return intentType;
+
+}

--- a/src/types/utils/slotsToTypes.ts
+++ b/src/types/utils/slotsToTypes.ts
@@ -5,7 +5,7 @@ import { existsAndNotEmpty } from "stentor-utils";
 
 const FS = "    ";
 
-export function slotsToTypes(slots: Slot[], name: string): string {
+export function slotsToTypes(slots: Slot[], name: string, availableEntities: { [type: string]: string }): string {
 
     let slotType = `export interface ${name} extends RequestSlotMap {\n`;
 
@@ -18,7 +18,8 @@ export function slotsToTypes(slots: Slot[], name: string): string {
 
             switch (slot.type) {
                 default:
-                    type = "string";
+                    // Try to grab it out of the map
+                    type = availableEntities[slot.type] || "string";
             }
 
             slotType += `${FS}${slotName}?: {\n`;

--- a/src/types/utils/slotsToTypes.ts
+++ b/src/types/utils/slotsToTypes.ts
@@ -1,0 +1,35 @@
+/*! Copyright (c) 2022, XAPP AI*/
+import { Slot } from "stentor-models";
+import { existsAndNotEmpty } from "stentor-utils";
+
+
+const FS = "    ";
+
+export function slotsToTypes(slots: Slot[], name: string): string {
+
+    let slotType = `export interface ${name} extends RequestSlotMap {\n`;
+
+    if (existsAndNotEmpty(slots)) {
+        slots.forEach((slot) => {
+
+            const slotName = slot.name;
+
+            let type: string;
+
+            switch (slot.type) {
+                default:
+                    type = "string";
+            }
+
+            slotType += `${FS}${slotName}?: {\n`;
+            slotType += `${FS}${FS}name: "${slotName}";\n`;
+            slotType += `${FS}${FS}value: ${type};\n`;
+            slotType += `${FS}};\n`;
+        });
+    }
+
+    // close it off
+    slotType += `}`;
+
+    return slotType;
+}


### PR DESCRIPTION
Adds a new function that will generate types for requests and their slots for a given app.

```bash
xapp types ./temp app-id -h "/*! Copyright (c) 2022, XAPP AI*/"
```

Will generate a file `studio.ts` in the `./temp` folder that has all the requests for the provided app with id `app-id`.  It will also place an header at the top `/*! Copyright (c) 2022, XAPP AI*/`