### PR TITLE
fix: Use generic RequestSlot on types generation

### DIFF
--- a/src/types/generateTypes.ts
+++ b/src/types/generateTypes.ts
@@ -52,7 +52,7 @@ export async function generateTypes(output: string, appId: string = undefined, o
         requests += `${options.header}\n`;
     }
     const HEADER = `/* This is a generated file */`;
-    const IMPORTS = `import { IntentRequest, Request, RequestSlotMap } from "stentor";`;
+    const IMPORTS = `import { IntentRequest, Request, RequestSlot, RequestSlotMap } from "stentor";`;
 
     requests += `${HEADER}\n${IMPORTS}\n\n`;
 

--- a/src/types/utils/slotsToTypes.ts
+++ b/src/types/utils/slotsToTypes.ts
@@ -22,15 +22,12 @@ export function slotsToTypes(slots: Slot[], name: string, availableEntities: { [
                     type = availableEntities[slot.type] || "string";
             }
 
-            slotType += `${FS}${slotName}?: {\n`;
-            slotType += `${FS}${FS}name: "${slotName}";\n`;
-            slotType += `${FS}${FS}value: ${type};\n`;
-            slotType += `${FS}};\n`;
+            slotType += `${FS}${slotName}?: RequestSlot<${type}>; \n`;
         });
     }
 
     // close it off
-    slotType += `}`;
+    slotType += `} `;
 
     return slotType;
 }


### PR DESCRIPTION
We were overriding the types and losing some of the values so this switches to RequestSlot