### PR TITLE
fix: Ability to be used as a module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -271,4 +271,8 @@ program
 
     });
 
-program.parse(process.argv);
+// Only tell commander to parse the args if this index.js is being called directly
+// This allows us to be used as a module if needed.
+if (require.main === module) {
+    program.parse(process.argv);
+}


### PR DESCRIPTION
CLI will not hijack the process.args unless it the CLIs index.js is being called directly.