### PR TITLE
fix: serve has environment: development

### DIFF
--- a/src/serve/serve.tsx
+++ b/src/serve/serve.tsx
@@ -23,7 +23,10 @@ export async function serve(props?: { url?: string, port?: string, appId?: strin
             serverUrl: url,
             type: "direct"
         },
-        serverUrl: url
+        serverUrl: url,
+        attributes: {
+            environment: "development"
+        }
     };
 
     const token = await getUserToken();


### PR DESCRIPTION
This sets the environment to "development" when using "xapp serve" to not pollute the analytics.